### PR TITLE
Configure Azure CNI Overlay networking in AKS

### DIFF
--- a/deployments/terraform/README.md
+++ b/deployments/terraform/README.md
@@ -23,7 +23,7 @@ This creates resource group, storage account and storage container for tfstate i
 
 3. In `deployments/terraform/environments/{prod|dev}` run:
 
-```tf
+```sh
 terraform init
 terraform plan
 terraform apply

--- a/deployments/terraform/environments/dev/main.tf
+++ b/deployments/terraform/environments/dev/main.tf
@@ -56,5 +56,6 @@ resource "azurerm_role_assignment" "example" {
 }
 
 module "helm" {
-  source = "../../modules/helm" 
+  source     = "../../modules/helm"
+  depends_on = [module.aks]
 }

--- a/deployments/terraform/environments/dev/main.tf
+++ b/deployments/terraform/environments/dev/main.tf
@@ -10,9 +10,9 @@ module "network" {
   location            = module.resource_group.location
   nsg_name            = "nsg-aks-dev"
   vnet_name           = "vnet-aks-dev"
-  subnet_name         = "snet-aks-dev"
-  address_space       = ["10.0.0.0/16"]
-  dns_servers         = ["10.0.0.4", "10.0.0.5"]
+  # subnet_name         = "snet-aks-dev"
+  # address_space       = ["10.1.0.0/16"]
+  # dns_servers         = ["10.0.0.4", "10.0.0.5"]
   # subnet_address_prefixes = ["10.0.0.0/24"]
 
   tags       = var.tags
@@ -39,10 +39,22 @@ module "aks" {
   default_node_pool_name = "default"
   node_count             = 1
   vm_size                = "Standard_B2ls_v2"
-  os_disk_size_gb        = 50
+  os_disk_size_gb        = 30
   subnet_id              = module.network.subnet1_id
   aks_nrg_name           = "nrg-dev-dailyquote"
 
   tags       = var.tags
   depends_on = [module.network]
+}
+
+# role assignment for aks acr pull
+resource "azurerm_role_assignment" "example" {
+  principal_id                     = module.aks.aks_kubelet_identity_object_id
+  role_definition_name             = "AcrPull"
+  scope                            = module.acr.acr_id
+  skip_service_principal_aad_check = true
+}
+
+module "helm" {
+  source = "../../modules/helm" 
 }

--- a/deployments/terraform/environments/dev/main.tf
+++ b/deployments/terraform/environments/dev/main.tf
@@ -5,16 +5,29 @@ module "resource_group" {
 }
 
 module "network" {
-  source                  = "../../modules/network"
-  resource_group_name     = module.resource_group.name
-  location                = module.resource_group.location
-  nsg_name                = "nsg-aks-dev"
-  vnet_name               = "vnet-aks-dev"
-  subnet_name             = "snet-aks-dev"
-  address_space           = ["10.0.0.0/16"]
-  subnet_address_prefixes = ["10.0.1.0/24"]
+  source              = "../../modules/network"
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  nsg_name            = "nsg-aks-dev"
+  vnet_name           = "vnet-aks-dev"
+  subnet_name         = "snet-aks-dev"
+  address_space       = ["10.0.0.0/16"]
+  dns_servers         = ["10.0.0.4", "10.0.0.5"]
+  # subnet_address_prefixes = ["10.0.0.0/24"]
 
-  tags = var.tags
+  tags       = var.tags
+  depends_on = [module.resource_group]
+}
+
+module "acr" {
+  source              = "../../modules/acr"
+  resource_group_name = var.rg_name
+  location            = var.location
+  acr_name            = "acrdevdailyquote"
+  acr_sku             = "Standard"
+
+  tags       = var.tags
+  depends_on = [module.resource_group]
 }
 
 module "aks" {
@@ -26,9 +39,10 @@ module "aks" {
   default_node_pool_name = "default"
   node_count             = 1
   vm_size                = "Standard_B2ls_v2"
+  os_disk_size_gb        = 50
+  subnet_id              = module.network.subnet1_id
+  aks_nrg_name           = "nrg-dev-dailyquote"
 
-  acr_name = "acrdevdailyquote"
-  acr_sku  = "Standard"
-
-  tags = var.tags
+  tags       = var.tags
+  depends_on = [module.network]
 }

--- a/deployments/terraform/environments/dev/outputs.tf
+++ b/deployments/terraform/environments/dev/outputs.tf
@@ -1,0 +1,17 @@
+output "resource_group_name" {
+  value = module.resource_group.name
+}
+
+output "kubernetes_cluster_name" {
+  value = module.aks.aks_cluster_name
+}
+
+output "client_certificate" {
+  value = module.aks.client_certificate
+  sensitive = true
+}
+
+output "kube_config" {
+  value = module.aks.kube_config
+  sensitive = true
+}

--- a/deployments/terraform/environments/dev/outputs.tf
+++ b/deployments/terraform/environments/dev/outputs.tf
@@ -7,11 +7,11 @@ output "kubernetes_cluster_name" {
 }
 
 output "client_certificate" {
-  value = module.aks.client_certificate
+  value     = module.aks.client_certificate
   sensitive = true
 }
 
 output "kube_config" {
-  value = module.aks.kube_config
+  value     = module.aks.kube_config
   sensitive = true
 }

--- a/deployments/terraform/environments/dev/providers.tf
+++ b/deployments/terraform/environments/dev/providers.tf
@@ -1,3 +1,18 @@
 provider "azurerm" {
   features {}
 }
+
+data "azurerm_kubernetes_cluster" "credentials" {
+  name                = module.aks.aks_cluster_name
+  resource_group_name = module.resource_group.name
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = data.azurerm_kubernetes_cluster.credentials.kube_config.0.host
+    client_certificate     = base64decode(data.azurerm_kubernetes_cluster.credentials.kube_config.0.client_certificate)
+    client_key             = base64decode(data.azurerm_kubernetes_cluster.credentials.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.credentials.kube_config.0.cluster_ca_certificate)
+
+  }
+}

--- a/deployments/terraform/environments/dev/providers.tf
+++ b/deployments/terraform/environments/dev/providers.tf
@@ -2,17 +2,12 @@ provider "azurerm" {
   features {}
 }
 
-data "azurerm_kubernetes_cluster" "credentials" {
-  name                = module.aks.aks_cluster_name
-  resource_group_name = module.resource_group.name
-}
 
 provider "helm" {
   kubernetes = {
-    host                   = data.azurerm_kubernetes_cluster.credentials.kube_config.0.host
-    client_certificate     = base64decode(data.azurerm_kubernetes_cluster.credentials.kube_config.0.client_certificate)
-    client_key             = base64decode(data.azurerm_kubernetes_cluster.credentials.kube_config.0.client_key)
-    cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.credentials.kube_config.0.cluster_ca_certificate)
-
+    host                   = module.aks.kube_config.0.host
+    client_certificate     = base64decode(module.aks.kube_config.0.client_certificate)
+    client_key             = base64decode(module.aks.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(module.aks.kube_config.0.cluster_ca_certificate)
   }
 }

--- a/deployments/terraform/environments/dev/terraform.tf
+++ b/deployments/terraform/environments/dev/terraform.tf
@@ -6,7 +6,7 @@ terraform {
     }
 
     helm = {
-      source = "hashicorp/helm"
+      source  = "hashicorp/helm"
       version = "~>3.0"
     }
   }

--- a/deployments/terraform/environments/dev/terraform.tf
+++ b/deployments/terraform/environments/dev/terraform.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>4.0"
     }
+
+    helm = {
+      source = "hashicorp/helm"
+      version = "~>3.0"
+    }
   }
 
   backend "azurerm" {

--- a/deployments/terraform/modules/acr/acr.tf
+++ b/deployments/terraform/modules/acr/acr.tf
@@ -1,0 +1,9 @@
+resource "azurerm_container_registry" "example" {
+  name                = var.acr_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = var.acr_sku
+  admin_enabled       = true
+
+  public_network_access_enabled = true
+}

--- a/deployments/terraform/modules/acr/outputs.tf
+++ b/deployments/terraform/modules/acr/outputs.tf
@@ -1,0 +1,3 @@
+output "acr_id" {
+  value = azurerm_container_registry.example.id
+}

--- a/deployments/terraform/modules/acr/variables.tf
+++ b/deployments/terraform/modules/acr/variables.tf
@@ -1,0 +1,27 @@
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Location (Region)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to set on the resource group"
+  type        = map(string)
+  default     = {}
+}
+
+variable "acr_name" {
+  description = "The name of the ACR"
+  type = string
+}
+
+variable "acr_sku" {
+  description = "SKU of the ACR"
+  type    = string
+  default = "Standard"
+}
+

--- a/deployments/terraform/modules/acr/variables.tf
+++ b/deployments/terraform/modules/acr/variables.tf
@@ -16,12 +16,12 @@ variable "tags" {
 
 variable "acr_name" {
   description = "The name of the ACR"
-  type = string
+  type        = string
 }
 
 variable "acr_sku" {
   description = "SKU of the ACR"
-  type    = string
-  default = "Standard"
+  type        = string
+  default     = "Standard"
 }
 

--- a/deployments/terraform/modules/aks/main.tf
+++ b/deployments/terraform/modules/aks/main.tf
@@ -6,13 +6,17 @@ resource "azurerm_kubernetes_cluster" "example" {
   node_resource_group = var.aks_nrg_name
 
   default_node_pool {
-    name           = var.default_node_pool_name
-    node_count     = var.node_count
-    vm_size        = var.vm_size
-    # vnet_subnet_id = var.subnet_id
-    os_disk_size_gb = var.os_disk_size_gb
-    node_public_ip_enabled = true
-    temporary_name_for_rotation = "tempdefault" 
+    name                        = var.default_node_pool_name
+    node_count                  = var.node_count
+    vm_size                     = var.vm_size
+    os_disk_size_gb             = var.os_disk_size_gb
+    node_public_ip_enabled      = true
+    temporary_name_for_rotation = "tempdefault"
+    auto_scaling_enabled        = true
+    min_count                   = 1
+    max_count                   = 3
+
+    vnet_subnet_id = var.subnet_id
   }
 
   identity {
@@ -21,13 +25,13 @@ resource "azurerm_kubernetes_cluster" "example" {
 
   role_based_access_control_enabled = true
 
+  network_profile {
+    network_plugin    = "azure"
+    network_policy    = "azure"
+    load_balancer_sku = "standard"
+    service_cidr      = var.network_cidr
+    dns_service_ip    = var.network_dns_ip
+  }
+
   tags = var.tags
 }
-
-# role assignment for aks acr pull
-# resource "azurerm_role_assignment" "example" {
-#   principal_id                     = azurerm_kubernetes_cluster.example.kubelet_identity[0].object_id
-#   role_definition_name             = "AcrPull"
-#   scope                            = azurerm_container_registry.example.id
-#   skip_service_principal_aad_check = true
-# }

--- a/deployments/terraform/modules/aks/main.tf
+++ b/deployments/terraform/modules/aks/main.tf
@@ -3,33 +3,31 @@ resource "azurerm_kubernetes_cluster" "example" {
   location            = var.location
   resource_group_name = var.resource_group_name
   dns_prefix          = var.dns_prefix
+  node_resource_group = var.aks_nrg_name
 
   default_node_pool {
-    name       = var.default_node_pool_name
-    node_count = var.node_count
-    vm_size    = var.vm_size
+    name           = var.default_node_pool_name
+    node_count     = var.node_count
+    vm_size        = var.vm_size
     # vnet_subnet_id = var.subnet_id
+    os_disk_size_gb = var.os_disk_size_gb
+    node_public_ip_enabled = true
+    temporary_name_for_rotation = "tempdefault" 
   }
 
   identity {
     type = "SystemAssigned"
   }
 
+  role_based_access_control_enabled = true
+
   tags = var.tags
 }
 
-resource "azurerm_container_registry" "example" {
-  name                = var.acr_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  sku                 = var.acr_sku
-  admin_enabled       = false
-}
-
 # role assignment for aks acr pull
-resource "azurerm_role_assignment" "example" {
-  principal_id                     = azurerm_kubernetes_cluster.example.kubelet_identity[0].object_id
-  role_definition_name             = "AcrPull"
-  scope                            = azurerm_container_registry.example.id
-  skip_service_principal_aad_check = true
-}
+# resource "azurerm_role_assignment" "example" {
+#   principal_id                     = azurerm_kubernetes_cluster.example.kubelet_identity[0].object_id
+#   role_definition_name             = "AcrPull"
+#   scope                            = azurerm_container_registry.example.id
+#   skip_service_principal_aad_check = true
+# }

--- a/deployments/terraform/modules/aks/main.tf
+++ b/deployments/terraform/modules/aks/main.tf
@@ -26,11 +26,13 @@ resource "azurerm_kubernetes_cluster" "example" {
   role_based_access_control_enabled = true
 
   network_profile {
-    network_plugin    = "azure"
-    network_policy    = "azure"
-    load_balancer_sku = "standard"
-    service_cidr      = var.network_cidr
-    dns_service_ip    = var.network_dns_ip
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    network_policy      = "azure"
+    load_balancer_sku   = "standard"
+    pod_cidr            = var.network_pod_cidr
+    service_cidr        = var.network_service_cidr
+    dns_service_ip      = var.network_dns_ip
   }
 
   tags = var.tags

--- a/deployments/terraform/modules/aks/outputs.tf
+++ b/deployments/terraform/modules/aks/outputs.tf
@@ -21,3 +21,7 @@ output "aks_cluster_name" {
 output "aks_cluster_kubernetes_version" {
   value = azurerm_kubernetes_cluster.example.kubernetes_version
 }
+
+output "aks_kubelet_identity_object_id" {
+  value = azurerm_kubernetes_cluster.example.kubelet_identity[0].object_id
+}

--- a/deployments/terraform/modules/aks/outputs.tf
+++ b/deployments/terraform/modules/aks/outputs.tf
@@ -4,10 +4,14 @@ output "client_certificate" {
   sensitive   = true
 }
 
-output "kube_config" {
+output "kube_config_raw" {
   description = "Raw Kubernetes config to be used by kubectl and other compatible tools"
   value       = azurerm_kubernetes_cluster.example.kube_config_raw
   sensitive   = true
+}
+
+output "kube_config" {
+  value = azurerm_kubernetes_cluster.example.kube_config
 }
 
 output "aks_cluster_id" {

--- a/deployments/terraform/modules/aks/outputs.tf
+++ b/deployments/terraform/modules/aks/outputs.tf
@@ -9,3 +9,15 @@ output "kube_config" {
   value       = azurerm_kubernetes_cluster.example.kube_config_raw
   sensitive   = true
 }
+
+output "aks_cluster_id" {
+  value = azurerm_kubernetes_cluster.example.id
+}
+
+output "aks_cluster_name" {
+  value = azurerm_kubernetes_cluster.example.name
+}
+
+output "aks_cluster_kubernetes_version" {
+  value = azurerm_kubernetes_cluster.example.kubernetes_version
+}

--- a/deployments/terraform/modules/aks/variables.tf
+++ b/deployments/terraform/modules/aks/variables.tf
@@ -44,7 +44,7 @@ variable "vm_size" {
 
 variable "os_disk_size_gb" {
   description = "The size of the vm disk size"
-  type        = string
+  type        = number
 }
 
 variable "subnet_id" {
@@ -58,4 +58,14 @@ variable "dns_prefix" {
   default     = "exampleaks1"
 }
 
+variable "network_dns_ip" {
+  description = "AKS network profile DNS service IP"
+  type        = string
+  default     = "10.0.0.10"
+}
 
+variable "network_cidr" {
+  description = "AKS network profile CIDR"
+  type        = string
+  default     = "10.0.0.0/16"
+}

--- a/deployments/terraform/modules/aks/variables.tf
+++ b/deployments/terraform/modules/aks/variables.tf
@@ -19,6 +19,11 @@ variable "aks_name" {
   type        = string
 }
 
+variable "aks_nrg_name" {
+  description = "Name of the AKS node resource group"
+  type        = string
+}
+
 variable "default_node_pool_name" {
   description = "Name of default pool node of AKS"
   type        = string
@@ -37,17 +42,20 @@ variable "vm_size" {
   default     = "Standard_B2ls_v2"
 }
 
+variable "os_disk_size_gb" {
+  description = "The size of the vm disk size"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "The ID of the subnet where the Kubernetes node pool should exist"
+  type        = string
+}
+
 variable "dns_prefix" {
   description = "Prefix of the DNS"
   type        = string
   default     = "exampleaks1"
 }
 
-variable "acr_name" {
-  type = string
-}
-variable "acr_sku" {
-  type    = string
-  default = "Standard"
-}
 

--- a/deployments/terraform/modules/aks/variables.tf
+++ b/deployments/terraform/modules/aks/variables.tf
@@ -58,14 +58,20 @@ variable "dns_prefix" {
   default     = "exampleaks1"
 }
 
+variable "network_service_cidr" {
+  description = "AKS network service CIDR"
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
 variable "network_dns_ip" {
   description = "AKS network profile DNS service IP"
   type        = string
-  default     = "10.0.0.10"
+  default     = "10.1.0.10"
 }
 
-variable "network_cidr" {
-  description = "AKS network profile CIDR"
+variable "network_pod_cidr" {
+  description = "AKS network pod CIDR"
   type        = string
-  default     = "10.0.0.0/16"
+  default     = "10.240.0.0/16"
 }

--- a/deployments/terraform/modules/helm/main.tf
+++ b/deployments/terraform/modules/helm/main.tf
@@ -1,0 +1,8 @@
+resource "helm_release" "nginx_ingress" {
+  name       = "nginx-ingress-controller"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx-ingress-controller"
+
+  namespace        = "ingress-nginx"
+  create_namespace = true
+}

--- a/deployments/terraform/modules/helm/main.tf
+++ b/deployments/terraform/modules/helm/main.tf
@@ -3,6 +3,12 @@ resource "helm_release" "nginx_ingress" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "nginx-ingress-controller"
 
+  set = [{
+    name  = "service.type"
+    value = "LoadBalancer"
+  }]
+
   namespace        = "ingress-nginx"
   create_namespace = true
+  wait             = false
 }

--- a/deployments/terraform/modules/network/README.md
+++ b/deployments/terraform/modules/network/README.md
@@ -7,8 +7,8 @@ This module creates a network security group (NSG), a virtual network (VNET) and
 ```tf
 module "network" {
   source                  = "../../modules/network"
-  resource_group_name     = "resource-group-name
-  location                = "polandcentral
+  resource_group_name     = "resource-group-name"
+  location                = "polandcentral"
   nsg_name                = "nsg-name"
   vnet_name               = "vnet-name"
   subnet_name             = "snet-name"

--- a/deployments/terraform/modules/network/main.tf
+++ b/deployments/terraform/modules/network/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network" "example" {
   name                = var.vnet_name
   location            = var.location
   resource_group_name = var.resource_group_name
-  address_space       = ["10.8.0.0/16"]
+  address_space       = ["192.168.0.0/16"]
   # dns_servers         = var.dns_servers
 
   tags = var.tags
@@ -18,18 +18,39 @@ resource "azurerm_subnet" "subnet1" {
   name                 = "subnet1"
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.8.0.0/21"]
+  address_prefixes     = ["192.168.0.0/16"]
 }
-
-# resource "azurerm_subnet" "subnet2" {
-#   name                 = "subnet2"
-#   resource_group_name  = var.resource_group_name
-#   virtual_network_name = azurerm_virtual_network.example.name
-#   address_prefixes     = ["10.8.0.0/21"]
-# }
 
 resource "azurerm_subnet_network_security_group_association" "example" {
   subnet_id                 = azurerm_subnet.subnet1.id
   network_security_group_id = azurerm_network_security_group.example.id
   depends_on                = [azurerm_network_security_group.example]
+}
+
+resource "azurerm_network_security_rule" "allow_http" {
+  name                        = "Allow-HTTP"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "80"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  network_security_group_name = azurerm_network_security_group.example.name
+  resource_group_name         = var.resource_group_name
+}
+
+resource "azurerm_network_security_rule" "allow_https" {
+  name                        = "Allow-HTTPS"
+  priority                    = 110
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  network_security_group_name = azurerm_network_security_group.example.name
+  resource_group_name         = var.resource_group_name
 }

--- a/deployments/terraform/modules/network/main.tf
+++ b/deployments/terraform/modules/network/main.tf
@@ -1,25 +1,35 @@
-resource "azurerm_virtual_network" "example" {
-  name                = var.vnet_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  address_space       = var.address_space
-}
-
-resource "azurerm_subnet" "example" {
-  name                 = var.subnet_name
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = var.subnet_address_prefixes
-}
-
 resource "azurerm_network_security_group" "example" {
   name                = var.nsg_name
   location            = var.location
   resource_group_name = var.resource_group_name
 }
 
-resource "azurerm_subnet_network_security_group_association" "example" {
-  subnet_id = azurerm_subnet.example.id
-  network_security_group_id = azurerm_network_security_group.example.id
-  depends_on = [azurerm_network_security_group.example]
+resource "azurerm_virtual_network" "example" {
+  name                = var.vnet_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  address_space       = var.address_space
+  dns_servers         = var.dns_servers
+
+  tags                = var.tags
 }
+
+resource "azurerm_subnet" "subnet1" {
+  name                 = "subnet1"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_subnet" "subnet2" {
+  name                 = "subnet2"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+# resource "azurerm_subnet_network_security_group_association" "example" {
+#   subnet_id                 = azurerm_subnet.example.id
+#   network_security_group_id = azurerm_network_security_group.example.id
+#   depends_on                = [azurerm_network_security_group.example]
+# }

--- a/deployments/terraform/modules/network/main.tf
+++ b/deployments/terraform/modules/network/main.tf
@@ -8,28 +8,28 @@ resource "azurerm_virtual_network" "example" {
   name                = var.vnet_name
   location            = var.location
   resource_group_name = var.resource_group_name
-  address_space       = var.address_space
-  dns_servers         = var.dns_servers
+  address_space       = ["10.8.0.0/16"]
+  # dns_servers         = var.dns_servers
 
-  tags                = var.tags
+  tags = var.tags
 }
 
 resource "azurerm_subnet" "subnet1" {
   name                 = "subnet1"
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.0.1.0/24"]
+  address_prefixes     = ["10.8.0.0/21"]
 }
 
-resource "azurerm_subnet" "subnet2" {
-  name                 = "subnet2"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.0.2.0/24"]
-}
-
-# resource "azurerm_subnet_network_security_group_association" "example" {
-#   subnet_id                 = azurerm_subnet.example.id
-#   network_security_group_id = azurerm_network_security_group.example.id
-#   depends_on                = [azurerm_network_security_group.example]
+# resource "azurerm_subnet" "subnet2" {
+#   name                 = "subnet2"
+#   resource_group_name  = var.resource_group_name
+#   virtual_network_name = azurerm_virtual_network.example.name
+#   address_prefixes     = ["10.8.0.0/21"]
 # }
+
+resource "azurerm_subnet_network_security_group_association" "example" {
+  subnet_id                 = azurerm_subnet.subnet1.id
+  network_security_group_id = azurerm_network_security_group.example.id
+  depends_on                = [azurerm_network_security_group.example]
+}

--- a/deployments/terraform/modules/network/outputs.tf
+++ b/deployments/terraform/modules/network/outputs.tf
@@ -1,9 +1,34 @@
+output "nsg_name" {
+  description = "The name of the nsg"
+  value       = azurerm_network_security_group.example.name
+}
+
 output "vnet_id" {
   description = "The ID of the vnet"
   value       = azurerm_virtual_network.example.id
 }
 
-output "subnet_id" {
-  description = "The ID of the subnet"
-  value       = azurerm_subnet.example.id
+output "vnet_name" {
+  description = "The name of the vnet"
+  value       = azurerm_virtual_network.example.name
+}
+
+output "subnet1_id" {
+  description = "The ID of the subnet1"
+  value       = azurerm_subnet.subnet1.id
+}
+
+output "subnet1_name" {
+  description = "The name of the subnet1"
+  value       = azurerm_subnet.subnet1.name
+}
+
+output "subnet2_id" {
+  description = "The ID of the subnet2"
+  value       = azurerm_subnet.subnet2.id
+}
+
+output "subnet2_name" {
+  description = "The name of the subnet2"
+  value       = azurerm_subnet.subnet2.name
 }

--- a/deployments/terraform/modules/network/outputs.tf
+++ b/deployments/terraform/modules/network/outputs.tf
@@ -23,12 +23,12 @@ output "subnet1_name" {
   value       = azurerm_subnet.subnet1.name
 }
 
-output "subnet2_id" {
-  description = "The ID of the subnet2"
-  value       = azurerm_subnet.subnet2.id
-}
+# output "subnet2_id" {
+#   description = "The ID of the subnet2"
+#   value       = azurerm_subnet.subnet2.id
+# }
 
-output "subnet2_name" {
-  description = "The name of the subnet2"
-  value       = azurerm_subnet.subnet2.name
-}
+# output "subnet2_name" {
+#   description = "The name of the subnet2"
+#   value       = azurerm_subnet.subnet2.name
+# }

--- a/deployments/terraform/modules/network/variables.tf
+++ b/deployments/terraform/modules/network/variables.tf
@@ -30,8 +30,8 @@ variable "vnet_name" {
 #   default     = ["10.8.0.0/16"]
 # }
 
-variable "dns_servers" {
-  type        = list(string)
-  description = "List of IP addresses of DNS servers"
-  default     = ["10.8.0.4", "10.8.0.5"]
-}
+# variable "dns_servers" {
+#   type        = list(string)
+#   description = "List of IP addresses of DNS servers"
+#   default     = ["10.0.0.4", "10.0.0.5"]
+# }

--- a/deployments/terraform/modules/network/variables.tf
+++ b/deployments/terraform/modules/network/variables.tf
@@ -30,6 +30,12 @@ variable "address_space" {
   default     = ["10.0.0.0/16"]
 }
 
+variable "dns_servers" {
+  type = list(string)
+  description = "List of IP addresses of DNS servers"
+  default = ["10.0.0.4", "10.0.0.5"]
+}
+
 variable "subnet_name" {
   description = "Name of the subnet"
   type        = string

--- a/deployments/terraform/modules/network/variables.tf
+++ b/deployments/terraform/modules/network/variables.tf
@@ -24,24 +24,14 @@ variable "vnet_name" {
   type        = string
 }
 
-variable "address_space" {
-  type        = list(string)
-  description = "The address space used by the virtual network"
-  default     = ["10.0.0.0/16"]
-}
+# variable "address_space" {
+#   type        = list(string)
+#   description = "The address space used by the virtual network"
+#   default     = ["10.8.0.0/16"]
+# }
 
 variable "dns_servers" {
-  type = list(string)
-  description = "List of IP addresses of DNS servers"
-  default = ["10.0.0.4", "10.0.0.5"]
-}
-
-variable "subnet_name" {
-  description = "Name of the subnet"
-  type        = string
-}
-variable "subnet_address_prefixes" {
   type        = list(string)
-  description = "The address prefixes for the subnet"
-  default     = ["10.0.1.0/24"]
+  description = "List of IP addresses of DNS servers"
+  default     = ["10.8.0.4", "10.8.0.5"]
 }


### PR DESCRIPTION
Applied custom networking.
Fixes accessibility of nginx deployed on AKS via helm chart. Just to test if service is accessible via public IP.

> - With Azure CNI Overlay, the cluster nodes are deployed into an Azure Virtual Network (VNet) subnet.
> - Pods are assigned IP addresses from a private CIDR logically different from the VNet hosting the nodes. Pod and node traffic within the cluster use an Overlay network.
[source](https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay?tabs=kubectl)