### PR TITLE
fix(ci): use my own PAT when creating tag and release

### DIFF
--- a/.github/workflows/build-push-acr.yml
+++ b/.github/workflows/build-push-acr.yml
@@ -62,3 +62,5 @@ jobs:
         run: |
           git tag "v${{ env.VERSION }}"
           git push origin --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,13 @@ jobs:
           images: ${{ env.REGISTRY_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           pull-images: false
         id: deploy-aks
+      
+      - name: Generate Changelog
+        run: echo "# Good things have arrived" > CHANGELOG.md
+      
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
There is a limitation of workflow: An action in a workflow run can't trigger a new workflow run. And I have another action that pushes to AKS on new tag creation.